### PR TITLE
Switch to System.Text.Json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,9 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v3.0.3
       with:
-        dotnet-version: 6.0.x
-    - name: Setup .NET Core 3.1 runtime
-      uses: actions/setup-dotnet@v3.0.3
-      with:
-        dotnet-version: 3.1.x
+        dotnet-version: |
+          7.0.x
+          6.0.x
     - name: Build
       run: dotnet build src --configuration Release
     - name: Upload packages

--- a/src/Particular.Approvals/Approver.cs
+++ b/src/Particular.Approvals/Approver.cs
@@ -2,8 +2,8 @@
 {
     using System;
     using System.IO;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
     using NUnit.Framework;
 
     /// <summary>
@@ -12,16 +12,16 @@
     public static class Approver
     {
         static readonly string approvalFilesPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "ApprovalFiles");
-        static readonly JsonSerializerSettings jsonSerializerSettings;
+        static readonly JsonSerializerOptions jsonSerializerOptions;
 
         static Approver()
         {
-            jsonSerializerSettings = new JsonSerializerSettings
+            jsonSerializerOptions = new JsonSerializerOptions
             {
-                Formatting = Formatting.Indented
+                WriteIndented = true
             };
 
-            jsonSerializerSettings.Converters.Add(new StringEnumConverter());
+            jsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
         }
 
         /// <summary>
@@ -64,7 +64,7 @@
         /// <param name="scenario">A value that will be added to the name of the approval file.</param>
         public static void Verify(object value, Func<string, string> scrubber = null, string scenario = null)
         {
-            var json = JsonConvert.SerializeObject(value, jsonSerializerSettings);
+            var json = JsonSerializer.Serialize(value, value.GetType(), jsonSerializerOptions);
 
             Verify(json, scrubber, scenario);
         }

--- a/src/Particular.Approvals/Particular.Approvals.csproj
+++ b/src/Particular.Approvals/Particular.Approvals.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Particular.Approvals/Particular.Approvals.csproj
+++ b/src/Particular.Approvals/Particular.Approvals.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="7.0.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
     <PackageReference Include="NUnit" Version="[3.11.0, 4.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Particular.Approvals/Particular.Approvals.csproj
+++ b/src/Particular.Approvals/Particular.Approvals.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
-    <PackageReference Include="NUnit" Version="[3.11.0, 4.0.0)" />
+    <PackageReference Include="NUnit" Version="[3.13.3, 4.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Particular.Approvals/Particular.Approvals.csproj
+++ b/src/Particular.Approvals/Particular.Approvals.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
+    <PackageReference Include="System.Text.Json" Version="7.0.0" />
     <PackageReference Include="NUnit" Version="[3.11.0, 4.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Alternative to #152 

Which would be my preference. Given that we can release it as 0.4 and then slowly adjust approval files when necessary, I think we should switch the serializer