### PR TITLE
Disable escaping of special characters

### DIFF
--- a/src/Particular.Approvals/Approver.cs
+++ b/src/Particular.Approvals/Approver.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Text.Encodings.Web;
     using System.Text.Json;
     using System.Text.Json.Serialization;
     using NUnit.Framework;
@@ -18,6 +19,7 @@
         {
             jsonSerializerOptions = new JsonSerializerOptions
             {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 WriteIndented = true
             };
 

--- a/src/Particular.Approvals/Particular.Approvals.csproj
+++ b/src/Particular.Approvals/Particular.Approvals.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
     <PackageReference Include="NUnit" Version="[3.13.3, 4.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/ApprovalFiles/ApproverTests.Can_process_complex_character_encodings_without_escaping.approved.txt
+++ b/src/Tests/ApprovalFiles/ApproverTests.Can_process_complex_character_encodings_without_escaping.approved.txt
@@ -1,0 +1,4 @@
+{
+  "Value1": "Foo => Bar // <br />",
+  "Value2": 0
+}

--- a/src/Tests/ApproverTests.cs
+++ b/src/Tests/ApproverTests.cs
@@ -47,6 +47,14 @@
 
             Approver.Verify(sample, s => s.Replace("42", "100"));
         }
+
+        [Test]
+        public void Can_process_complex_character_encodings_without_escaping()
+        {
+            var sample = new Sample { Value1 = "Foo => Bar // <br />" };
+
+            Approver.Verify(sample);
+        }
     }
 
     class Sample

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" PrivateAssets="All"/>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
As it turns out, by default the serializer tries to escape some characters, which newtonsoft didn't do. This caused some test failures in core

https://github.com/Particular/NServiceBus/pull/6702#issuecomment-1468022132

Given this is a test library and we want to avoid any sort of special treatment on string I think it should be safe to switch over to `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`

https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/character-encoding#serialize-all-characters