### PR TITLE
Better approval feedback

### DIFF
--- a/src/Tests/ApiCasingProblems.cs
+++ b/src/Tests/ApiCasingProblems.cs
@@ -1,0 +1,49 @@
+﻿namespace Tests
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.InteropServices;
+    using NUnit.Framework;
+    using Particular.Approvals;
+
+    [TestFixture]
+    class ApiCasingProblems
+    {
+        [TestCase("Feedback_on_casing_problems")]
+        [TestCase("Feedback_ON_casing_PROBLEMS")]
+        public void Feedback_on_casing_problems(string overrideMemberName)
+        {
+            var text = "Text to approve";
+
+            try
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    var exception = Assert.Throws<Exception>(() => Approver.Verify(text, callerMemberName: overrideMemberName));
+                    Assert.That(exception.Message, Contains.Substring("case-insensitive match"));
+                }
+                else
+                {
+                    // Windows and MacOS are case insensitive
+                    Approver.Verify(text, callerMemberName: overrideMemberName);
+                }
+            }
+            finally
+            {
+                // File must be cleaned up or will ruin other runtime tests
+                var approvalFilesPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..", "..", "..", "ApprovalFiles");
+                var pattern = $"{nameof(ApiCasingProblems)}.{nameof(Feedback_on_casing_problems)}.approved.txt";
+                var directory = new DirectoryInfo(approvalFilesPath);
+                var matchingFiles = directory.GetFiles()
+                    .Where(f => f.Name.Equals(pattern, StringComparison.OrdinalIgnoreCase) && !f.Name.Equals("APICasingProblems.Feedback_on_casing_problems.approved.txt", StringComparison.Ordinal));
+
+                foreach (var file in matchingFiles)
+                {
+                    file.Delete();
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/ApprovalFiles/APICasingProblems.Feedback_on_casing_problems.approved.txt
+++ b/src/Tests/ApprovalFiles/APICasingProblems.Feedback_on_casing_problems.approved.txt
@@ -1,0 +1,1 @@
+Text to approve

--- a/src/Tests/ApprovalFiles/DiffOutputTests.LongWithNewlineCharacters.ExceptionText.approved.txt
+++ b/src/Tests/ApprovalFiles/DiffOutputTests.LongWithNewlineCharacters.ExceptionText.approved.txt
@@ -1,0 +1,7 @@
+Approval verification failed.
+ - Approval File: DiffOutputTests.LongWithNewlineCharacters.OriginalTest.approved.txt (length=939)
+ - Received File: DiffOutputTests.LongWithNewlineCharacters.OriginalTest.received.txt (length=958)
+
+Approved: imperdiet enim et justo iaculis cursus.\nAenean dictum urna sed egestas ultrices.
+Received: imperdiet enim et justo iaculis cursus.\n---PROBLEM HERE---\nAenean dictum urna se
+---------------------------------------------------^

--- a/src/Tests/ApprovalFiles/DiffOutputTests.LongWithNewlineCharacters.OriginalTest.approved.txt
+++ b/src/Tests/ApprovalFiles/DiffOutputTests.LongWithNewlineCharacters.OriginalTest.approved.txt
@@ -1,0 +1,20 @@
+Lorem ipsum dolor sit amet.
+Consectetur adipiscing elit.
+Aliquam et arcu at lacus tincidunt tempus.
+Aliquam ultricies odio sit amet.
+Velit convallis, sit amet maximus nisi rhoncus.
+Phasellus eu quam gravida.
+Euismod arcu non, posuere metus.
+Maecenas sed nisi sed magna consectetur bibendum.
+Sed non lectus ornare. iaculis magna et, laoreet ipsum.
+Aenean imperdiet enim et justo iaculis cursus.
+Aenean dictum urna sed egestas ultrices.
+Duis lobortis massa quis enim suscipit pellentesque porta sodales mi.
+Fusce eget mi eget ex consequat sagittis.
+Sed lobortis ligula nec rhoncus luctus.
+Curabitur vel nunc vel dolor feugiat lacinia id vitae erat.
+Duis pulvinar metus at lacus consequat posuere.
+Nullam non libero sit amet tortor imperdiet hendrerit.
+Curabitur id nisi feugiat, scelerisque leo vitae, euismod metus.
+Sed ornare massa sit amet nulla pharetra, a commodo turpis maximus.
+Aenean et orci in mi scelerisque tristique non in quam.

--- a/src/Tests/ApprovalFiles/DiffOutputTests.ShortTest.ExceptionText.approved.txt
+++ b/src/Tests/ApprovalFiles/DiffOutputTests.ShortTest.ExceptionText.approved.txt
@@ -1,0 +1,7 @@
+Approval verification failed.
+ - Approval File: DiffOutputTests.ShortTest.OriginalTest.approved.txt (length=46)
+ - Received File: DiffOutputTests.ShortTest.OriginalTest.received.txt (length=45)
+
+Approved: I am the very model of a modern major general.
+Received: I am the very NOPE of a modern major general.
+------------------------^

--- a/src/Tests/ApprovalFiles/DiffOutputTests.ShortTest.OriginalTest.approved.txt
+++ b/src/Tests/ApprovalFiles/DiffOutputTests.ShortTest.OriginalTest.approved.txt
@@ -1,0 +1,1 @@
+I am the very model of a modern major general.

--- a/src/Tests/DiffOutputTests.cs
+++ b/src/Tests/DiffOutputTests.cs
@@ -1,0 +1,55 @@
+﻿namespace Tests
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
+    using NUnit.Framework;
+    using Particular.Approvals;
+
+    [TestFixture]
+    class DiffOutputTests
+    {
+        static readonly string approvalFilesPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..", "..", "..", "ApprovalFiles");
+
+        [Test]
+        public void ShortTest() => Test("I am the very NOPE of a modern major general.");
+
+        [Test]
+        public void LongWithNewlineCharacters()
+        {
+            var text = @"Lorem ipsum dolor sit amet.
+Consectetur adipiscing elit.
+Aliquam et arcu at lacus tincidunt tempus.
+Aliquam ultricies odio sit amet.
+Velit convallis, sit amet maximus nisi rhoncus.
+Phasellus eu quam gravida.
+Euismod arcu non, posuere metus.
+Maecenas sed nisi sed magna consectetur bibendum.
+Sed non lectus ornare. iaculis magna et, laoreet ipsum.
+Aenean imperdiet enim et justo iaculis cursus.
+---PROBLEM HERE---
+Aenean dictum urna sed egestas ultrices.
+Duis lobortis massa quis enim suscipit pellentesque porta sodales mi.
+Fusce eget mi eget ex consequat sagittis.
+Sed lobortis ligula nec rhoncus luctus.
+Curabitur vel nunc vel dolor feugiat lacinia id vitae erat.
+Duis pulvinar metus at lacus consequat posuere.
+Nullam non libero sit amet tortor imperdiet hendrerit.
+Curabitur id nisi feugiat, scelerisque leo vitae, euismod metus.
+Sed ornare massa sit amet nulla pharetra, a commodo turpis maximus.
+Aenean et orci in mi scelerisque tristique non in quam.
+";
+
+            Test(text);
+        }
+
+        void Test(string text, [CallerMemberName] string callerMemberName = null)
+        {
+            var exception = Assert.Throws<Exception>(() => Approver.Verify(text, scenario: "OriginalTest", callerMemberName: callerMemberName));
+            var originalTestFile = Path.Combine(approvalFilesPath, $"{nameof(DiffOutputTests)}.{callerMemberName}.OriginalTest.received.txt");
+            File.Delete(originalTestFile);
+            Approver.Verify(exception.Message, scenario: "ExceptionText", callerMemberName: callerMemberName);
+        }
+    }
+}


### PR DESCRIPTION
* Better feedback messages for when one file is missing, especially in weird casing scenarios on Linux.
* Diff view on the surrounding 30 characters on either side of the first difference in exception message.

Approval failed exception messages will now look more like this:

```
Approval verification failed.
 - Approval File: DiffOutputTests.ShortTest.OriginalTest.approved.txt (length=46)
 - Received File: DiffOutputTests.ShortTest.OriginalTest.received.txt (length=45)

Approved: I am the very model of a modern major general.
Received: I am the very NOPE of a modern major general.
------------------------^
```